### PR TITLE
Share user statistics instead of app url

### DIFF
--- a/src/components/ShareStats.jsx
+++ b/src/components/ShareStats.jsx
@@ -73,8 +73,7 @@ const ShareStats = ({ timeRange }) => {
       try {
         await navigator.share({
           title: 'Momentum - My Activity Progress',
-          text: shareText,
-          url: window.location.href
+          text: shareText
         });
         showToast(t('statistics.shareSuccess'));
       } catch (error) {


### PR DESCRIPTION
Remove app URL from Web Share API call to share only user statistics.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0f8db2b-3aea-4748-89c9-99b3f4310020">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0f8db2b-3aea-4748-89c9-99b3f4310020">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

